### PR TITLE
Updated scripts to publish versions only

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -1,4 +1,4 @@
-name: Run Mike Deploy
+name: Release a New Version
 
 # Controls when the workflow will run
 on:
@@ -10,7 +10,7 @@ on:
 
   # Triggers when a new release is published
   release:
-    types: [released, edited]
+    types: [released]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Setup Git environment
         run: |
           git fetch origin gh-pages --depth=1
-          git config --global user.name circularlizard
-          git config --global user.email david.strachan@mac.com
+          git config --global user.name hcl-digital-experience
+          git config --global user.email notarealemail@hcl.dx
       - name: Run Mike deploy
         env: 
           RELEASE_TAG_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Setup Git environment
         run: |
           git fetch origin gh-pages --depth=1
-          git config --global user.name circularlizard
-          git config --global user.email david.strachan@mac.com
+          git config --global user.name hcl-digital-experience
+          git config --global user.email notarealemail@hcl.dx
       - name: Run Mike deploy
         env: 
           RELEASE_TAG_VERSION: ${{ github.event.release.tag_name }}

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,51 @@
+name: Update a Version
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  # push:
+  #  branches: [ main ]
+  # pull_request:
+  #  branches: [ main ]
+
+  # Triggers when a new release is published
+  release:
+    types: [edited]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      # Build and publish the site
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.x
+      # Install python pre-reqs
+      - name: Install Mkdocs and pre-reqs
+        run: |
+          pip install mkdocs-material
+          pip install mkdocs-awesome-pages-plugin
+          pip install mkdocs-git-revision-date-plugin
+          pip install mike
+      # Do the actual deployment
+      - name: Setup Git environment
+        run: |
+          git fetch origin gh-pages --depth=1
+          git config --global user.name circularlizard
+          git config --global user.email david.strachan@mac.com
+      - name: Run Mike deploy
+        env: 
+          RELEASE_TAG_VERSION: ${{ github.event.release.tag_name }}
+        run: |
+          mike deploy ${RELEASE_TAG_VERSION} --push


### PR DESCRIPTION
This PR updates the scripts so that we have 2 site update scripts

- release-version.yml -- this one is triggered when a new release is published, and publishes a new version of the doc and sets it to be the "latest" version
- update-version.yml -- this is triggered when a release is edited, and updates the published doc for that version