### PR TITLE
Tweaked script to capitalize release name

### DIFF
--- a/.github/workflows/release-version.yml
+++ b/.github/workflows/release-version.yml
@@ -45,4 +45,4 @@ jobs:
         env: 
           RELEASE_TAG_VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mike deploy -u ${RELEASE_TAG_VERSION} latest --push
+          mike deploy -u ${RELEASE_TAG_VERSION^^} latest --push

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -45,4 +45,4 @@ jobs:
         env: 
           RELEASE_TAG_VERSION: ${{ github.event.release.tag_name }}
         run: |
-          mike deploy ${RELEASE_TAG_VERSION} --push
+          mike deploy ${RELEASE_TAG_VERSION^^} --push


### PR DESCRIPTION
This is a tiny tweak to the deployment scripts to capitalize the release name in case the tag used contains lower case letters

Tested at https://circularlizard.github.io/dx-test-doc/NEW-ONE/