### PR TITLE
Added some hints and tips based for manual configuration

### DIFF
--- a/docs/deployment/manage/container_configuration/kubernetes_remote_search.md
+++ b/docs/deployment/manage/container_configuration/kubernetes_remote_search.md
@@ -253,6 +253,9 @@ kubectl cp dx-core-0:/home/dx_user/LTPAKeyExported ./LTPAKeyExported -c core -n 
 
 ### Configure the Remote Search Pod
 
+!!!note
+    Before configuring the remote search pod, you must set up single sign-on (SSO) between the WebSphere Application Server running in the **core** pod and the WebSphere Application Server running in the **remote-search** pod. See the topics [Single sign-on for authentication using LTPA cookies](https://www.ibm.com/docs/en/was/9.0.5?topic=authentication-single-sign-using-ltpa-cookies) and [Creating a single-sign on domain between HCL Portal and the remote search service](../../../build_sites/search/remotesearch/sso_portal_rss.md) for pre-requisites and instructions for setting up SSO.
+
 Copy the LTPA Key exported from DX Core into the Remote Search Pod:
 
 ```sh
@@ -270,9 +273,6 @@ kubectl exec -it -n dxns dx-remote-search-0 -c remote-search -- /bin/bash
 # Ensure to use the right credentials for DWasPassword
 /opt/HCL/AppServer/profiles/prs_profile/ConfigEngine/./ConfigEngine.sh configure-remote-search-server-for-remote-search -DWasPassword=[WAS ADMIN PASSWORD] -Dportal.host.name="dx-core" -Dportal.port.number="10042" -Dportal.cert.alias="portaldockeralias" -Dremote.search.host.name="localhost"
 ```
-!!!note
-    You have to setup SSO between the WebSphere Application Server running in the **core** pod(s) and the WebSphere Application Server running in the **remote-search** pod before proceeding.  See [authentication-single-sign-using-ltpa-cookies](https://www.ibm.com/docs/en/was/9.0.5?topic=authentication-single-sign-using-ltpa-cookies) and [Creating a single-sign on domain between HCL Portal and the remote search service | HCL Digital Experience](https://help.hcltechsw.com/digital-experience/9.5/admin-system/sso_portal_rss.html) for more detailed instructions and pre-requisits setting up SSO.
-
 ### Restart both Core and Remote Search
 
 To restart Remote Search:
@@ -396,13 +396,9 @@ Create the following Content Source:
 
 In the `Security` panel, use the DX Core Service name (e.g., `dx-core`) as the host name, along with the username `wpsadmin` and the associated password for `wpsadmin`. You can also specify Realm as CrawlerUsersRealm.
 
-!!!Note
-    You need to press the _create_ button to create the security realm definition inside the frame where you entered the data first to have the security realm defintion before saving the content source
-
-!!!tip
-    Note: The host `dx-core` and port `10042` are the Kubernetes service host and the port for DX Core. In this case, 10042 is the HttpQueueInboundDefaultSecure port on the HCL DX 9.5 server.  Adjust this according to your deployment configuration.
-
-!!!note
-    The parsing of the `SeedlistId` positional parameter in this URL uses an index of the virtual portal being crawled. In this case 1 (in 2 places) represents the base virtual portal.
+!!!note "Notes"
+    - Click the **create** button to create the security realm definition inside the frame where you first entered the data. This action ensures that you have the security realm defintion before saving the content source.
+    - The host `dx-core` and port `10042` are the Kubernetes service host and the port for DX Core. In this case, 10042 is the HttpQueueInboundDefaultSecure port on the HCL DX 9.5 server. Adjust this according to your deployment configuration.
+    - The parsing of the `SeedlistId` positional parameter in this URL uses an index of the virtual portal being crawled. In this case, 1 (in 2 places) represents the base virtual portal.
 
 

--- a/docs/deployment/manage/container_configuration/kubernetes_remote_search.md
+++ b/docs/deployment/manage/container_configuration/kubernetes_remote_search.md
@@ -270,6 +270,8 @@ kubectl exec -it -n dxns dx-remote-search-0 -c remote-search -- /bin/bash
 # Ensure to use the right credentials for DWasPassword
 /opt/HCL/AppServer/profiles/prs_profile/ConfigEngine/./ConfigEngine.sh configure-remote-search-server-for-remote-search -DWasPassword=[WAS ADMIN PASSWORD] -Dportal.host.name="dx-core" -Dportal.port.number="10042" -Dportal.cert.alias="portaldockeralias" -Dremote.search.host.name="localhost"
 ```
+!!!note
+    You have to setup SSO between the WebSphere Application Server running in the **core** pod(s) and the WebSphere Application Server running in the **remote-search** pod before proceeding.  See [authentication-single-sign-using-ltpa-cookies](https://www.ibm.com/docs/en/was/9.0.5?topic=authentication-single-sign-using-ltpa-cookies) and [Creating a single-sign on domain between HCL Portal and the remote search service | HCL Digital Experience](https://help.hcltechsw.com/digital-experience/9.5/admin-system/sso_portal_rss.html) for more detailed instructions and pre-requisits setting up SSO.
 
 ### Restart both Core and Remote Search
 
@@ -393,6 +395,9 @@ Create the following Content Source:
 |Collect documents linked from this URL|`https://dx-core:10042/wps/seedlist/myserver?Action=GetDocuments&Format=ATOM&Locale=en_US&Range=100&Source=com.ibm.lotus.search.plugins.seedlist.retriever.jcr.JCRRetrieverFactory&Start=0&SeedlistId=1@OOTB_CRAWLER1`|
 
 In the `Security` panel, use the DX Core Service name (e.g., `dx-core`) as the host name, along with the username `wpsadmin` and the associated password for `wpsadmin`. You can also specify Realm as CrawlerUsersRealm.
+
+!!!Note
+    You need to press the _create_ button to create the security realm definition inside the frame where you entered the data first to have the security realm defintion before saving the content source
 
 !!!tip
     Note: The host `dx-core` and port `10042` are the Kubernetes service host and the port for DX Core. In this case, 10042 is the HttpQueueInboundDefaultSecure port on the HCL DX 9.5 server.  Adjust this according to your deployment configuration.


### PR DESCRIPTION
-  Added a note that SSO configuration is required between core and remote-search pod.
- Added a hint to not forget the create button when creating the security realm in the content source