### PR TITLE
Update Guardyourcookies.md

### DIFF
--- a/docs/guide_me/guides/SecurityHardeningGuide/Guardyourcookies.md
+++ b/docs/guide_me/guides/SecurityHardeningGuide/Guardyourcookies.md
@@ -74,6 +74,6 @@ JSESSIONID ([Java Servlet specification](https://www.oracle.com/java/technologie
 - Consider setting HTTPOnly for any other cookies your application might leverage, at the [web container level](https://www.ibm.com/docs/en/was/9.0.5?topic=configuration-web-container-custom-properties#blockingjavascriptaccess). 
 
 - If the controls above prove insufficient for any application cookies, consider setting attributes at the web server (with [mod_headers.so](https://publib.boulder.ibm.com/httpserv/manual70/mod/mod_headers.html)): 
-    Header edit Set Cookie ^(.*)$ $1;HttpOnly;Secure
+    Header edit Set-Cookie ^(.*)$ $1;HttpOnly;Secure
     or
-    Header set Set Cookie HttpOnly;Secure
+    Header set Set-Cookie HttpOnly;Secure


### PR DESCRIPTION
Error in httpd.conf line to add the parameter. You put "Set Cookie" but is "Set-Cookie" (with middle dash)

# Pull Request Template

Thank you for your contribution!

## Description

Please provide a summary of the changes and the related issue.

- What does this PR do? Change the document with an error in a httpd.conf sentence (missing a middle dash)
- Why is it needed? The actually sentence don´t generate an error but don´t execute the action
- Any relevant context or background?

## Checklist

- [ ] I have updated relevant documentation in `docs/` or elsewhere as needed
- [ ] I have checked that the documentation builds
- [ ] I have checked spelling, grammar, captialisation and other style rules
- [ ] I have fixed any broken links in the pages that I have amended



## Additional Notes

Add any other information or questions for reviewers here.


